### PR TITLE
Revamped Collision Detection

### DIFF
--- a/DW3Arduino/entity.h
+++ b/DW3Arduino/entity.h
@@ -6,8 +6,8 @@
 
 typedef struct Entity_t
 {
-   Vector4r32_t hitBox;
-   Vector4r32_t prevHitBox;
+   Vector4r32_t pos;
+   Vector4r32_t prevPos;
    Vector2r32_t velocity;
 }
 Entity_t;

--- a/DW3Arduino/game.c
+++ b/DW3Arduino/game.c
@@ -21,11 +21,11 @@ void Game_Init( Game_t* game, u16* screenBuffer )
    game->tileMap.viewportScreenPos.y = 10;
 
    game->playerEntity = &game->tileMap.entities[PLAYER_ENTITY_INDEX];
-   game->playerEntity->hitBox.x = 24.0f;
-   game->playerEntity->hitBox.y = 24.0f;
-   game->playerEntity->hitBox.w = 12.0f;
-   game->playerEntity->hitBox.h = 12.0f;
-   game->playerEntity->prevHitBox = game->playerEntity->hitBox;
+   game->playerEntity->pos.x = 24.0f;
+   game->playerEntity->pos.y = 24.0f;
+   game->playerEntity->pos.w = 12.0f;
+   game->playerEntity->pos.h = 12.0f;
+   game->playerEntity->prevPos = game->playerEntity->pos;
    game->playerEntity->velocity.x = 0.0f;
    game->playerEntity->velocity.y = 0.0f;
 
@@ -36,8 +36,8 @@ void Game_Tic( Game_t* game )
 {
    Input_Read( &game->input );
    Game_HandleInput( game );
-   Game_TicPhysics( game );
-   Game_Draw( game );
+   Physics_Tic( game );
+   Render_DrawGame( game );
 }
 
 internal void Game_HandleInput( Game_t* game )

--- a/DW3Arduino/game.h
+++ b/DW3Arduino/game.h
@@ -28,10 +28,10 @@ void Game_Init( Game_t* game, u16* screenBuffer );
 void Game_Tic( Game_t* game );
 
 // physics.c
-void Game_TicPhysics( Game_t* game );
+void Physics_Tic( Game_t* game );
 
 // render.c
-void Game_Draw( Game_t* game );
+void Render_DrawGame( Game_t* game );
 
 #if defined( __cplusplus )
 }

--- a/DW3Arduino/game_data.c
+++ b/DW3Arduino/game_data.c
@@ -95,11 +95,11 @@ void TileMap_LoadFromIndex( TileMap_t* tileMap, u32 index )
    {
       if ( i != PLAYER_ENTITY_INDEX )
       {
-         tileMap->entities[i].hitBox.w = 14.0f;
-         tileMap->entities[i].hitBox.h = 14.0f;
-         tileMap->entities[i].hitBox.x = (r32)( Random_u32( 1, ( tileMap->tilesX - 2 ) * TILE_SIZE ) );
-         tileMap->entities[i].hitBox.y = (r32)( Random_u32( 1, ( tileMap->tilesY - 2 ) * TILE_SIZE ) );
-         tileMap->entities[i].prevHitBox = tileMap->entities[i].hitBox;
+         tileMap->entities[i].pos.w = 14.0f;
+         tileMap->entities[i].pos.h = 14.0f;
+         tileMap->entities[i].pos.x = (r32)( Random_u32( 1, ( tileMap->tilesX - 2 ) * TILE_SIZE ) );
+         tileMap->entities[i].pos.y = (r32)( Random_u32( 1, ( tileMap->tilesY - 2 ) * TILE_SIZE ) );
+         tileMap->entities[i].prevPos = tileMap->entities[i].pos;
          tileMap->entities[i].velocity.x = 0.0f;
          tileMap->entities[i].velocity.y = 0.0f;
       }

--- a/DW3Arduino/physics.c
+++ b/DW3Arduino/physics.c
@@ -1,38 +1,13 @@
 #include "game.h"
 #include "utility.h"
 
-internal void Game_ClipEntityToEntity( Entity_t* entity, Entity_t* rigidEntity, Bool_t movingLeft, Bool_t movingRight, Bool_t movingUp, Bool_t movingDown );
-internal void Game_ClipEntityToTileMap( Game_t* game, Entity_t* entity, Bool_t movingLeft, Bool_t movingRight, Bool_t movingUp, Bool_t movingDown );
+internal void Physics_MoveEntities( Game_t* game );
+internal Bool_t Physics_EntityCollidesWithTileMap( TileMap_t* tileMap, Entity_t* entity, r32 sign, Bool_t horizontal );
+internal Bool_t Physics_EntityCollidesWithEntities( TileMap_t* tileMap, Entity_t* entity, r32 sign, Bool_t horizontal );
 
-void Game_TicPhysics( Game_t* game )
+void Physics_Tic( Game_t* game )
 {
-   u32 i, j;
-   Entity_t *entity, *rigidEntity;
-   Bool_t movingLeft, movingRight, movingUp, movingDown;
-
-   // move entities and do clipping
-   for ( i = 0, entity = game->tileMap.entities; i < game->tileMap.entityCount; i++, entity++ )
-   {
-      entity->prevHitBox.x = entity->hitBox.x;
-      entity->prevHitBox.y = entity->hitBox.y;
-      entity->hitBox.x += ( entity->velocity.x * CLOCK_FRAME_SECONDS );
-      entity->hitBox.y += ( entity->velocity.y * CLOCK_FRAME_SECONDS );
-
-      movingLeft = entity->hitBox.x < entity->prevHitBox.x;
-      movingRight = entity->hitBox.x > entity->prevHitBox.x;
-      movingUp = entity->hitBox.y < entity->prevHitBox.y;
-      movingDown = entity->hitBox.y > entity->prevHitBox.y;
-
-      for ( j = 0, rigidEntity = game->tileMap.entities; j < game->tileMap.entityCount; j++, rigidEntity++ )
-      {
-         if ( entity != rigidEntity )
-         {
-            Game_ClipEntityToEntity( entity, rigidEntity, movingLeft, movingRight, movingUp, movingDown );
-         }
-      }
-
-      Game_ClipEntityToTileMap( game, entity, movingLeft, movingRight, movingUp, movingDown );
-   }
+   Physics_MoveEntities( game );
 
    // reset player velocity and clamp the viewport to the player
    game->playerEntity->velocity.x = 0.0f;
@@ -41,384 +16,206 @@ void Game_TicPhysics( Game_t* game )
    TileMap_ClampViewportToEntity( &game->tileMap, game->playerEntity );
 }
 
-internal void Game_ClipEntityToEntity( Entity_t* entity, Entity_t* obstacle, Bool_t movingLeft, Bool_t movingRight, Bool_t movingUp, Bool_t movingDown )
+internal void Physics_MoveEntities( Game_t* game )
 {
-   Vector4r32_t collider = obstacle->hitBox;
-   Vector4r32_t resolvedPos = entity->hitBox;
-   Bool_t upperLeftCollision, lowerLeftCollision, upperRightCollision, lowerRightCollision;
-   Bool_t leftSideCollision, rightSideCollision, topSideCollision, bottomSideCollision;
-   r32 colliderR, colliderB, resolvedPosR, resolvedPosB;
+   u32 i;
+   i32 pixelsRemaining;
+   r32 deltaX, deltaY, deltaRemaining, sign;
+   Entity_t* entity;
 
-   if ( !Utility_RectsIntersect32r( entity->hitBox.x, entity->hitBox.y, entity->hitBox.w, entity->hitBox.h,
-                                    collider.x, collider.y, collider.w, collider.h ) )
+   // the idea for this came from Maddy Thorson's game, Celeste. instead of setting an entity's
+   // new position and doing collision resolution, we just move a pixel at a time and check for collisions.
+   // it may not be very performant though, we'll have to keep an eye on that.
+   for ( i = 0, entity = game->tileMap.entities; i < game->tileMap.entityCount; i++, entity++ )
    {
-      return;
-   }
-
-   colliderR = collider.x + collider.w;
-   colliderB = collider.y + collider.h;
-   resolvedPosR = entity->hitBox.x + entity->hitBox.w;
-   resolvedPosB = entity->hitBox.y + entity->hitBox.h;
-
-   if ( movingLeft || movingRight )
-   {
-      upperLeftCollision = Utility_PointInRect32r( entity->hitBox.x, entity->hitBox.y, collider.x, collider.y, collider.w, collider.h );
-      lowerLeftCollision = Utility_PointInRect32r( entity->hitBox.x, resolvedPosB, collider.x, collider.y, collider.w, collider.h );
-      upperRightCollision = Utility_PointInRect32r( resolvedPosR, entity->hitBox.y, collider.x, collider.y, collider.w, collider.h );
-      lowerRightCollision = Utility_PointInRect32r( resolvedPosR, resolvedPosB, collider.x, collider.y, collider.w, collider.h );
-
-      leftSideCollision = Utility_VerticalLineIntersectsRect32r( entity->hitBox.x, entity->hitBox.y, resolvedPosB, collider.x, collider.y, collider.w, collider.h);
-      rightSideCollision = Utility_VerticalLineIntersectsRect32r( resolvedPosR, entity->hitBox.y, resolvedPosB, collider.x, collider.y, collider.w, collider.h);
+      deltaX = entity->velocity.x * CLOCK_FRAME_SECONDS;
+      deltaY = entity->velocity.y * CLOCK_FRAME_SECONDS;
 
       // horizontal pass
-      if ( leftSideCollision )
+      if ( deltaX != 0.0f )
       {
-         if ( ( upperLeftCollision && lowerLeftCollision ) || ( !upperLeftCollision && !lowerLeftCollision ) ) // entire left side is colliding
+         deltaRemaining = deltaX;
+         sign = ( deltaX < 0.0f ) ? -1.0f : 1.0f;
+         pixelsRemaining = (i32)deltaX;
+
+         // move full pixels first, one at a time
+         while ( pixelsRemaining != 0 )
          {
-            resolvedPos.x = colliderR;
-         }
-         else if ( upperLeftCollision )
-         {
-            if ( !upperRightCollision ) // the lowerLeftCollision case will be handled in the vertical pass
+            entity->pos.x += sign;
+
+            if ( Physics_EntityCollidesWithTileMap( &game->tileMap, entity, sign, True ) ||
+                 Physics_EntityCollidesWithEntities( &game->tileMap, entity, sign, True ) )
             {
-               // only upper-left corner is colliding. if we're moving up, resolve based on collision depth
-               if ( !movingUp || ( ( colliderR - resolvedPos.x ) < ( colliderB - resolvedPos.y ) ) )
-               {
-                  resolvedPos.x = colliderR;
-               }
+               entity->pos.x = entity->prevPos.x;
+               break;
             }
-         }
-         else if ( lowerLeftCollision )
-         {
-            if ( !lowerRightCollision ) // the lowerRightCollision case will be handled in the vertical pass
+            else
             {
-               // only lower-left corner is colliding. if we're moving down, resolve based on collision depth
-               if ( !movingDown || ( ( colliderR - resolvedPos.x ) < ( resolvedPosB - collider.y ) ) )
-               {
-                  resolvedPos.x = colliderR;
-               }
+               entity->prevPos.x = entity->pos.x;
+            }
+
+            deltaRemaining -= sign;
+            pixelsRemaining -= (i32)sign;
+         }
+
+         // move remaining sub-pixels
+         if ( deltaRemaining != 0.0f )
+         {
+            entity->pos.x += deltaRemaining;
+
+            if ( Physics_EntityCollidesWithTileMap( &game->tileMap, entity, sign, True ) ||
+                 Physics_EntityCollidesWithEntities( &game->tileMap, entity, sign, True ) )
+            {
+               entity->pos.x = entity->prevPos.x;
+            }
+            else
+            {
+               entity->prevPos.x = entity->pos.x;
             }
          }
       }
-      else if ( rightSideCollision )
-      {
-         if ( ( upperRightCollision && lowerRightCollision ) || ( !upperRightCollision && !lowerRightCollision ) ) // entire right side is colliding
-         {
-            resolvedPos.x = collider.x - resolvedPos.w - COLLISION_THETA;
-         }
-         else if ( upperRightCollision )
-         {
-            if ( !upperLeftCollision ) // the upperLeftCollision case will be handled in the vertical pass
-            {
-               // only upper-right corner is colliding. if we're moving up, resolve based on collision depth
-               if ( !movingUp || ( ( resolvedPosR - collider.x ) < ( colliderB - resolvedPos.y ) ) )
-               {
-                  resolvedPos.x = ( collider.x - resolvedPos.w - COLLISION_THETA );
-               }
-            }
-         }
-         else if ( lowerRightCollision )
-         {
-            if ( !lowerLeftCollision ) // the lowerLeftCollision case will be handled in the vertical pass
-            {
-               // only lower-right corner is colliding. if we're moving down, resolve based on collision depth
-               if ( !movingDown || ( ( resolvedPosR - collider.x ) < ( resolvedPosB - collider.y ) ) )
-               {
-                  resolvedPos.x = ( collider.x - resolvedPos.w - COLLISION_THETA );
-               }
-            }
-         }
-      }
-
-      entity->hitBox.x = resolvedPos.x;
-      resolvedPosR = entity->hitBox.x + entity->hitBox.w;
-
-      if ( !Utility_RectsIntersect32r( entity->hitBox.x, entity->hitBox.y, entity->hitBox.w, entity->hitBox.h,
-                                       collider.x, collider.y, collider.w, collider.h ) )
-      {
-         return;
-      }
-   }
-
-   if ( movingUp || movingDown )
-   {
-      upperLeftCollision = Utility_PointInRect32r( entity->hitBox.x, entity->hitBox.y, collider.x, collider.y, collider.w, collider.h );
-      lowerLeftCollision = Utility_PointInRect32r( entity->hitBox.x, resolvedPosB, collider.x, collider.y, collider.w, collider.h );
-      upperRightCollision = Utility_PointInRect32r( resolvedPosR, entity->hitBox.y, collider.x, collider.y, collider.w, collider.h );
-      lowerRightCollision = Utility_PointInRect32r( resolvedPosR, resolvedPosB, collider.x, collider.y, collider.w, collider.h );
-
-      topSideCollision = Utility_HorizontalLineIntersectsRect32r( entity->hitBox.x, resolvedPosR, entity->hitBox.y, collider.x, collider.y, collider.w, collider.h );
-      bottomSideCollision = Utility_HorizontalLineIntersectsRect32r( entity->hitBox.x, resolvedPosR, resolvedPosB, collider.x, collider.y, collider.w, collider.h );
 
       // vertical pass
-      if ( topSideCollision )
+      if ( deltaY != 0.0f )
       {
-         if ( ( upperLeftCollision && upperRightCollision ) || ( !upperLeftCollision && !upperRightCollision ) ) // entire top side is colliding
-         {
-            resolvedPos.y = colliderB;
-         }
-         else if ( upperLeftCollision )
-         {
-            // only upper-left corner is colliding. if we're moving left, resolve based on collision depth
-            if ( !movingLeft || ( ( colliderR - resolvedPos.x ) > ( colliderB - resolvedPos.y ) ) )
-            {
-               resolvedPos.y = colliderB;
-            }
-         }
-         else if ( upperRightCollision )
-         {
-            // only upper-right corner is colliding. if we're moving right, resolve based on collision depth
-            if ( !movingRight || ( ( resolvedPosR - collider.x ) > ( colliderB - resolvedPos.y ) ) )
-            {
-               resolvedPos.y = colliderB;
-            }
-         }
-      }
-      else if ( bottomSideCollision )
-      {
-         if ( ( lowerLeftCollision && lowerRightCollision ) || ( !lowerLeftCollision && !lowerRightCollision ) ) // entire bottom side is colliding
-         {
-            resolvedPos.y = collider.y - resolvedPos.h - COLLISION_THETA;
-         }
-         else if ( lowerLeftCollision )
-         {
-            // only lower-left corner is colliding. if we're moving left, resolve based on collision depth
-            if ( !movingLeft || ( ( colliderR - resolvedPos.x ) > ( resolvedPosB - collider.y ) ) )
-            {
-               resolvedPos.y = ( collider.y - resolvedPos.h - COLLISION_THETA );
-            }
-         }
-         else if ( lowerRightCollision )
-         {
-            // only lower-right corner is colliding. if we're moving right, resolve based on collision depth
-            if ( !movingRight || ( ( resolvedPosR - collider.x ) > ( resolvedPosB - collider.y ) ) )
-            {
-               resolvedPos.y = ( collider.y - resolvedPos.h - COLLISION_THETA );
-            }
-         }
-      }
+         deltaRemaining = deltaY;
+         sign = ( deltaY < 0.0f ) ? -1.0f : 1.0f;
+         pixelsRemaining = (i32)deltaY;
 
-      entity->hitBox.y = resolvedPos.y;
+         // move full pixels first, one at a time
+         while ( pixelsRemaining != 0 )
+         {
+            entity->pos.y += sign;
+
+            if ( Physics_EntityCollidesWithTileMap( &game->tileMap, entity, sign, False ) ||
+                 Physics_EntityCollidesWithEntities( &game->tileMap, entity, sign, False ) )
+            {
+               entity->pos.y = entity->prevPos.y;
+               break;
+            }
+            else
+            {
+               entity->prevPos.y = entity->pos.y;
+            }
+
+            deltaRemaining -= sign;
+            pixelsRemaining -= (i32)sign;
+         }
+
+         // move remaining sub-pixels
+         if ( deltaRemaining != 0.0f )
+         {
+            entity->pos.y += deltaRemaining;
+
+            if ( Physics_EntityCollidesWithTileMap( &game->tileMap, entity, sign, False ) ||
+                 Physics_EntityCollidesWithEntities( &game->tileMap, entity, sign, False ) )
+            {
+               entity->pos.y = entity->prevPos.y;
+            }
+            else
+            {
+               entity->prevPos.y = entity->pos.y;
+            }
+         }
+      }
    }
 }
 
-// IMPORTANT NOTE:
-//
-// This type of clipping only works if the entity's hit box is smaller than the tile size,
-// so it's very important not to make any entities that are larger than a map tile!
-internal void Game_ClipEntityToTileMap( Game_t* game, Entity_t* entity, Bool_t movingLeft, Bool_t movingRight, Bool_t movingUp, Bool_t movingDown )
+internal Bool_t Physics_EntityCollidesWithTileMap( TileMap_t* tileMap, Entity_t* entity, r32 sign, Bool_t horizontal )
 {
-   r32 xDepth, yDepth;
+   u32 i;
+   u16 tile;
+   u32 start, end, side;
 
-   u32 topTileRow = (u32)( entity->hitBox.y / TILE_SIZE );
-   u32 bottomTileRow = (u32)( ( entity->hitBox.y + entity->hitBox.h ) / TILE_SIZE );
-   u32 leftTileCol = (u32)( entity->hitBox.x / TILE_SIZE );
-   u32 rightTileCol = (u32)( ( entity->hitBox.x + entity->hitBox.w  ) / TILE_SIZE );
-
-   u16 upperLeftTile = game->tileMap.tiles[leftTileCol + ( topTileRow * game->tileMap.tilesX )];
-   u16 upperRightTile = game->tileMap.tiles[rightTileCol + ( topTileRow * game->tileMap.tilesX )];
-   u16 lowerLeftTile = game->tileMap.tiles[leftTileCol + ( bottomTileRow * game->tileMap.tilesX )];
-   u16 lowerRightTile = game->tileMap.tiles[rightTileCol + ( bottomTileRow * game->tileMap.tilesX )];
-
-   Bool_t upperLeftPassable = TILE_GET_IS_PASSABLE( upperLeftTile );
-   Bool_t upperRightPassable = TILE_GET_IS_PASSABLE( upperRightTile );
-   Bool_t lowerLeftPassable = TILE_GET_IS_PASSABLE( lowerLeftTile );
-   Bool_t lowerRightPassable = TILE_GET_IS_PASSABLE( lowerRightTile );
-
-   if ( upperLeftPassable && upperRightPassable && lowerLeftPassable && lowerRightPassable )
+   if ( horizontal )
    {
-      return;
-   }
+      start = (u32)( entity->pos.y / TILE_SIZE );                    // top row
+      end = (u32)( ( entity->pos.y + entity->pos.h ) / TILE_SIZE );  // bottom row
+      side = ( sign < 0.0f )
+         ? (u32)( entity->pos.x / TILE_SIZE )                        // left side
+         : (u32)( ( entity->pos.x + entity->pos.w  ) / TILE_SIZE );  // right side
 
-   movingLeft = entity->hitBox.x < entity->prevHitBox.x;
-   movingRight = entity->hitBox.x > entity->prevHitBox.x;
-   movingUp = entity->hitBox.y < entity->prevHitBox.y;
-   movingDown = entity->hitBox.y > entity->prevHitBox.y;
+      for ( i = start; i <= end; i++ )
+      {
+         tile = tileMap->tiles[side + ( i * tileMap->tilesX )];
 
-   if ( !upperLeftPassable && !upperRightPassable && !lowerLeftPassable && !lowerRightPassable ) // fully surrounded by un-passable tiles
-   {
-      // this shouldn't be possible, but let's not clip just in case, or the entity could get stuck.
-      return;
-   }
-   else if ( !upperRightPassable && !lowerLeftPassable )
-   {
-      if ( !lowerRightPassable || ( movingRight || movingDown ) ) // colliding with a lower-right corner (presumably)
-      {
-         entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-         entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
-      }
-      else if ( !upperLeftPassable || ( movingUp || movingLeft ) ) // colliding with an upper-left corner (presumably)
-      {
-         entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
-         entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-      }
-   }
-   else if ( !upperLeftPassable && !lowerRightPassable )
-   {
-      if ( !lowerLeftPassable || ( movingLeft || movingDown ) ) // colliding with a lower-left corner (presumably)
-      {
-         entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
-         entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
-      }
-      else if ( !upperRightPassable || ( movingRight || movingUp ) ) // colliding with an upper-right corner (presumably)
-      {
-         entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-         entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-      }
-   }
-   else if ( !upperLeftPassable )
-   {
-      if ( !lowerLeftPassable ) // colliding with left wall
-      {
-         entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
-      }
-      else if ( !upperRightPassable ) // colliding with upper wall
-      {
-         entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-      }
-      else // colliding with upper-left tile only
-      {
-         if ( movingLeft && movingUp )
+         if ( !TILE_GET_IS_PASSABLE( tile ) )
          {
-            xDepth = ( ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE ) - entity->hitBox.x;
-            yDepth = ( ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE ) - entity->hitBox.y;
-
-            if ( xDepth > yDepth )
-            {
-               entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-            }
-            else
-            {
-               entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
-            }
+            return True;
          }
-         else if ( movingLeft )
+      }
+   }
+   else
+   {
+      start = (u32)( entity->pos.x / TILE_SIZE );                    // left col
+      end = (u32)( ( entity->pos.x + entity->pos.w ) / TILE_SIZE );  // right col
+      side = ( sign < 0.0f )
+         ? (u32)( entity->pos.y / TILE_SIZE )                        // top side
+         : (u32)( ( entity->pos.y + entity->pos.h  ) / TILE_SIZE );  // bottom side
+
+      for ( i = start; i <= end; i++ )
+      {
+         tile = tileMap->tiles[i + ( side * tileMap->tilesX )];
+
+         if ( !TILE_GET_IS_PASSABLE( tile ) )
          {
-            entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
+            return True;
+         }
+      }
+   }
+
+   return False;
+}
+
+internal Bool_t Physics_EntityCollidesWithEntities( TileMap_t* tileMap, Entity_t* entity, r32 sign, Bool_t horizontal )
+{
+   u32 i;
+   Entity_t* rigidEntity;
+
+   for ( i = 0, rigidEntity = tileMap->entities; i < tileMap->entityCount; i++, rigidEntity++ )
+   {
+      if ( entity != rigidEntity )
+      {
+         if ( horizontal )
+         {
+            if ( sign < 0.0f ) // moving left
+            {
+               if ( Utility_VerticalLineIntersectsRect32r( entity->pos.x, entity->pos.y, entity->pos.y + entity->pos.h,
+                                                           rigidEntity->pos.x, rigidEntity->pos.y, rigidEntity->pos.w, rigidEntity->pos.h ) )
+               {
+                  return True;
+               }
+            }
+            else // moving right
+            {
+               if ( Utility_VerticalLineIntersectsRect32r( entity->pos.x + entity->pos.w, entity->pos.y, entity->pos.y + entity->pos.h,
+                                                           rigidEntity->pos.x, rigidEntity->pos.y, rigidEntity->pos.w, rigidEntity->pos.h ) )
+               {
+                  return True;
+               }
+            }
          }
          else
          {
-            entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-         }
-      }
-   }
-   else if ( !lowerLeftPassable )
-   {
-      if ( !lowerRightPassable ) // colliding with lower wall
-      {
-         entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
-      }
-      else if ( !upperRightPassable ) // colliding with right wall
-      {
-         entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-      }
-      else // colliding with lower-left tile only
-      {
-         if ( movingLeft && movingDown )
-         {
-            xDepth = ( ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE ) - entity->hitBox.x;
-            yDepth = ( entity->hitBox.y + entity->hitBox.h ) - ( ( (r32)bottomTileRow * TILE_SIZE ) );
-
-            if ( xDepth > yDepth )
+            if ( sign < 0.0f ) // moving up
             {
-               entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
+               if ( Utility_HorizontalLineIntersectsRect32r( entity->pos.x, entity->pos.x + entity->pos.w, entity->pos.y,
+                                                             rigidEntity->pos.x, rigidEntity->pos.y, rigidEntity->pos.w, rigidEntity->pos.h ) )
+               {
+                  return True;
+               }
             }
-            else
+            else // moving down
             {
-               entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
+               if ( Utility_HorizontalLineIntersectsRect32r( entity->pos.x, entity->pos.x + entity->pos.w, entity->pos.y + entity->pos.h,
+                                                             rigidEntity->pos.x, rigidEntity->pos.y, rigidEntity->pos.w, rigidEntity->pos.h ) )
+               {
+                  return True;
+               }
             }
-         }
-         else if ( movingLeft )
-         {
-            entity->hitBox.x = ( (r32)leftTileCol * TILE_SIZE ) + TILE_SIZE;
-         }
-         else
-         {
-            entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
-         }
-      }
-   }
-   else if ( !upperRightPassable )
-   {
-      if ( !lowerRightPassable ) // colliding with right wall
-      {
-         entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-      }
-      else // colliding with upper-right tile only
-      {
-         if ( movingRight && movingUp )
-         {
-            xDepth = ( entity->hitBox.x + entity->hitBox.w ) - ( ( (r32)rightTileCol * TILE_SIZE ) );
-            yDepth = ( ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE ) - entity->hitBox.y;
-
-            if ( xDepth > yDepth )
-            {
-               entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-            }
-            else
-            {
-               entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-            }
-         }
-         else if ( movingRight )
-         {
-            entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-         }
-         else
-         {
-            entity->hitBox.y = ( (r32)topTileRow * TILE_SIZE ) + TILE_SIZE;
-         }
-      }
-   }
-   else if ( !lowerRightPassable )
-   {
-      if ( !lowerLeftPassable ) // colliding with lower wall
-      {
-         entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
-      }
-      else // colliding with lower-right tile only
-      {
-         if ( movingRight && movingDown )
-         {
-            xDepth = ( entity->hitBox.x + entity->hitBox.w ) - ( ( (r32)rightTileCol * TILE_SIZE ) );
-            yDepth = ( entity->hitBox.y + entity->hitBox.h ) - ( ( (r32)bottomTileRow * TILE_SIZE ) );
-
-            if ( xDepth > yDepth )
-            {
-               entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
-            }
-            else
-            {
-               entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-            }
-         }
-         else if ( movingRight )
-         {
-            entity->hitBox.x = ( (r32)rightTileCol * TILE_SIZE ) - entity->hitBox.w - COLLISION_THETA;
-         }
-         else
-         {
-            entity->hitBox.y = ( (r32)bottomTileRow * TILE_SIZE ) - entity->hitBox.h - COLLISION_THETA;
          }
       }
    }
 
-   // clip to tile map boundaries
-   if ( entity->hitBox.x < 0.0f )
-   {
-      entity->hitBox.x = 0.0f;
-   }
-   else if ( ( entity->hitBox.x + entity->hitBox.w ) >= (r32)( game->tileMap.tilesX * TILE_SIZE ) )
-   {
-      entity->hitBox.x = ( r32 )( ( game->tileMap.tilesX * TILE_SIZE ) - entity->hitBox.w ) - COLLISION_THETA;
-   }
-
-   if ( entity->hitBox.y < 0.0f )
-   {
-      entity->hitBox.y = 0.0f;
-   }
-   else if ( ( entity->hitBox.y + entity->hitBox.h ) >= (r32)( game->tileMap.tilesY * TILE_SIZE ) )
-   {
-      entity->hitBox.y = ( r32 )( ( game->tileMap.tilesY * TILE_SIZE ) - entity->hitBox.h ) - COLLISION_THETA;
-   }
+   return False;
 }

--- a/DW3Arduino/render.c
+++ b/DW3Arduino/render.c
@@ -1,18 +1,18 @@
 #include "game.h"
 #include "utility.h"
 
-internal void Game_DrawTileMap( Game_t* game );
-internal void Game_DrawEntities( Game_t* game );
+internal void Render_DrawTileMap( Game_t* game );
+internal void Render_DrawEntities( Game_t* game );
 
-void Game_Draw( Game_t* game )
+void Render_DrawGame( Game_t* game )
 {
    Screen_WipeColor( &game->screen, COLOR16_BLACK );
-   Game_DrawTileMap( game );
-   Game_DrawEntities( game );
+   Render_DrawTileMap( game );
+   Render_DrawEntities( game );
    Screen_Blit( &game->screen );
 }
 
-internal void Game_DrawTileMap( Game_t* game )
+internal void Render_DrawTileMap( Game_t* game )
 {
    i32 tileOffsetX, tileOffsetY;
    i32 startTileX, endTileX, startTileY, endTileY;
@@ -88,7 +88,7 @@ internal void Game_DrawTileMap( Game_t* game )
    }
 }
 
-internal void Game_DrawEntities( Game_t* game )
+internal void Render_DrawEntities( Game_t* game )
 {
    u32 i;
    Entity_t* entity = game->tileMap.entities;
@@ -97,13 +97,13 @@ internal void Game_DrawEntities( Game_t* game )
 
    for ( i = 0; i < game->tileMap.entityCount; i++ )
    {
-      if ( Utility_RectsIntersect32i( (i32)entity->hitBox.x, (i32)entity->hitBox.y, (i32)entity->hitBox.w, (i32)entity->hitBox.h,
+      if ( Utility_RectsIntersect32i( (i32)entity->pos.x, (i32)entity->pos.y, (i32)entity->pos.w, (i32)entity->pos.h,
                                       viewport->x, viewport->y, viewport->w, viewport->h ) )
       {
          Screen_DrawBoundedRect( &game->screen,
-                                 ( (i32)( entity->hitBox.x ) - viewport->x ) + viewportScreenPos->x,
-                                 ( (i32)( entity->hitBox.y ) - viewport->y ) + viewportScreenPos->y,
-                                 (i32)( entity->hitBox.w ), (i32)( entity->hitBox.h ),
+                                 ( (i32)( entity->pos.x ) - viewport->x ) + viewportScreenPos->x,
+                                 ( (i32)( entity->pos.y ) - viewport->y ) + viewportScreenPos->y,
+                                 (i32)( entity->pos.w ), (i32)( entity->pos.h ),
                                  viewportScreenPos->x, viewportScreenPos->y,
                                  viewportScreenPos->x + viewport->w,
                                  viewportScreenPos->y + viewport->h,

--- a/DW3Arduino/tile_map.c
+++ b/DW3Arduino/tile_map.c
@@ -24,11 +24,11 @@ void TileMap_Init( TileMap_t* tileMap )
    {
       tileMap->entities[i].velocity.x = 0.0f;
       tileMap->entities[i].velocity.y = 0.0f;
-      tileMap->entities[i].hitBox.x = 0.0f;
-      tileMap->entities[i].hitBox.y = 0.0f;
-      tileMap->entities[i].hitBox.w = 0.0f;
-      tileMap->entities[i].hitBox.h = 0.0f;
-      tileMap->entities[i].prevHitBox = tileMap->entities[i].hitBox;
+      tileMap->entities[i].pos.x = 0.0f;
+      tileMap->entities[i].pos.y = 0.0f;
+      tileMap->entities[i].pos.w = 0.0f;
+      tileMap->entities[i].pos.h = 0.0f;
+      tileMap->entities[i].prevPos = tileMap->entities[i].pos;
    }
 }
 
@@ -41,7 +41,7 @@ void TileMap_ClampViewportToEntity( TileMap_t* tileMap, Entity_t* entity )
    }
    else
    {
-      tileMap->viewport.x = (i32)( entity->hitBox.x + ( entity->hitBox.w / 2 ) ) - ( tileMap->viewport.w / 2 );
+      tileMap->viewport.x = (i32)( entity->pos.x + ( entity->pos.w / 2 ) ) - ( tileMap->viewport.w / 2 );
 
       // clamp to left or right edge if necessary
       if ( tileMap->viewport.x < 0 )
@@ -61,7 +61,7 @@ void TileMap_ClampViewportToEntity( TileMap_t* tileMap, Entity_t* entity )
    }
    else
    {
-      tileMap->viewport.y = (i32)( entity->hitBox.y + ( entity->hitBox.h / 2 ) ) - ( tileMap->viewport.h / 2 );
+      tileMap->viewport.y = (i32)( entity->pos.y + ( entity->pos.h / 2 ) ) - ( tileMap->viewport.h / 2 );
 
       // clamp to top or bottom edge if necessary
       if ( tileMap->viewport.y < 0 )


### PR DESCRIPTION
Addresses Issue: #3 

## Overview

After spending WAY too much time trying to figure all this stuff out, I stumbled on this post:

https://maddythorson.medium.com/celeste-and-towerfall-physics-d24bd2ae0fc5

This is an outline of how collisions are done in Celeste, using an AABB check, but with a little twist. Instead of moving entities the entire distance and THEN doing collision detection, it moves entities one pixel at a time, and re-checks for collisions each time. Afterward, it applies sub-pixels and does one last check.

This may not be very performant, but I think we'll be fine since we only move a maximum of like 1.3 pixels per frame. Plus the math is super simple, so it shouldn't be a problem. Finally, it's time to move on!