### PR TITLE
Fixed a bug with drawing tiles at the top of the map

### DIFF
--- a/DW3Arduino/render.c
+++ b/DW3Arduino/render.c
@@ -111,11 +111,6 @@ internal void Render_DrawTileMapSection( Game_t* game, i32 vx, i32 vy, i32 vw, i
 
    endTileX = ( ( vx + vw ) / TILEMAP_TILE_SIZE );
 
-   if ( ( ( vx + vw ) % TILEMAP_TILE_SIZE ) != 0 )
-   {
-      endTileX++;
-   }
-
    if ( endTileX >= (i32)( game->tileMap.tilesX ) )
    {
       endTileX = (i32)( game->tileMap.tilesX - 1 );
@@ -134,11 +129,6 @@ internal void Render_DrawTileMapSection( Game_t* game, i32 vx, i32 vy, i32 vw, i
    }
 
    endTileY = ( ( vy + vh ) / TILEMAP_TILE_SIZE );
-
-   if ( ( ( vy + vw ) % TILEMAP_TILE_SIZE ) != 0 )
-   {
-      endTileY++;
-   }
 
    if ( endTileY >= (i32)( game->tileMap.tilesY ) )
    {

--- a/DW3Arduino/screen.c
+++ b/DW3Arduino/screen.c
@@ -72,5 +72,9 @@ void Screen_DrawBoundedBuffer8( Screen_t* screen, u8* buffer,
             bufferPos++;
          }
       }
+      else
+      {
+         bufferPos += bufferWidth;
+      }
    }
 }


### PR DESCRIPTION
Addresses Issue: #17 

## Overview

I never noticed this before because I was testing with solid color tiles, but the `Screen_DrawBoundedBuffer8` function had a bug where I wasn't advancing the buffer position when the buffer went out of bounds on the top. This should fix that, and incidentally also cleans up some most-likely-useless checking of whether we should draw an extra tile on the right/bottom.