### PR TITLE
Draw entities in the correct z-order

### DIFF
--- a/DW3Arduino/render.c
+++ b/DW3Arduino/render.c
@@ -215,39 +215,6 @@ internal void Render_DrawStaticSpritesInSection( Game_t* game, i32 vx, i32 vy, i
    }
 }
 
-internal void Render_FunDrawFunction( Game_t* game, Entity_t** entities, u32 entityCount, i32 vx, i32 vy, i32 vw, i32 vh, i32 xOffset, i32 yOffset )
-{
-   u32 i, startPos;
-   ActiveSpriteTexture_t* textures;
-   Entity_t* entity;
-   Vector2u32_t* viewportScreenPos = &game->tileMap.viewportScreenPos;
-
-   for ( i = 0; i < entityCount; i++, entity++ )
-   {
-      entity = entities[i];
-
-      if ( Utility_RectsIntersect32i( (i32)entity->pos.x, (i32)entity->pos.y, (i32)entity->pos.w, (i32)entity->pos.h, vx, vy, vw, vh ) )
-      {
-         if ( entity->sprite->frame > 0 )
-         {
-            entity->sprite->frame = entity->sprite->frame;
-         }
-
-         startPos = ( ACTIVE_SPRITE_FRAME_PIXELS * ACTIVE_SPRITE_FRAMES ) * entity->sprite->direction + ( ACTIVE_SPRITE_FRAME_PIXELS * entity->sprite->frame );
-         textures = ( entity == game->player.entity ) ? game->tileMap.playerSpriteTextures : game->tileMap.activeSpriteTextures;
-
-         Screen_DrawBoundedBuffer8( &game->screen,
-                                    textures[entity->sprite->textureIndex].paletteIndexes + startPos,
-                                    ACTIVE_SPRITE_FRAME_SIZE, ACTIVE_SPRITE_FRAME_SIZE,
-                                    ( (i32)( entity->pos.x ) - vx - entity->sprite->offset.x ) + viewportScreenPos->x + xOffset,
-                                    ( (i32)( entity->pos.y ) - vy - entity->sprite->offset.y ) + viewportScreenPos->y + yOffset,
-                                    viewportScreenPos->x + xOffset, viewportScreenPos->y + yOffset,
-                                    viewportScreenPos->x + vw + xOffset,
-                                    viewportScreenPos->y + vh + yOffset );
-      }
-   }
-}
-
 internal void Render_DrawEntitiesInSection( Game_t* game, i32 vx, i32 vy, i32 vw, i32 vh, i32 xOffset, i32 yOffset )
 {
    Entity_t* sortedEntities[TILEMAP_MAX_ENTITIES + TILEMAP_MAX_PLAYER_OBJECTS];


### PR DESCRIPTION
## Overview

Although it's not possible for entity hit boxes to overlap, their sprites still can. This just adds a pretty rudimentary method of sorting all entities in Z-order before rendering, so whatever is "behind" (aka has a lower Y position) gets drawn first. I think it might be more correct to check Y + Height, but since everything will probably have the same height anyway, it shouldn't be an issue.