### PR TITLE
Use unsigned ints whenever possible

### DIFF
--- a/DW3ArduinoWinDev/DW3ArduinoEditor/SaveData/ActiveSpriteSaveData.cs
+++ b/DW3ArduinoWinDev/DW3ArduinoEditor/SaveData/ActiveSpriteSaveData.cs
@@ -6,13 +6,13 @@ namespace DW3ArduinoEditor.SaveData
 {
    public class ActiveSpriteSaveData
    {
-      public int TextureIndex { get; set; }
+      public uint TextureIndex { get; set; }
       public Vector2f Offset { get; set; } = new( 0, 0 );
       public Direction StartDirection { get; set; }
 
       public ActiveSpriteSaveData() { }
 
-      public ActiveSpriteSaveData( int textureIndex, Vector2f offset, Direction startDirection )
+      public ActiveSpriteSaveData( uint textureIndex, Vector2f offset, Direction startDirection )
       {
          TextureIndex = textureIndex;
          Offset = offset;

--- a/DW3ArduinoWinDev/DW3ArduinoEditor/SaveData/StaticSpriteSaveData.cs
+++ b/DW3ArduinoWinDev/DW3ArduinoEditor/SaveData/StaticSpriteSaveData.cs
@@ -4,13 +4,13 @@ namespace DW3ArduinoEditor.SaveData
 {
    public class StaticSpriteSaveData
    {
-      public int TextureIndex { get; set; }
-      public int TileIndex { get; set; }
+      public uint TextureIndex { get; set; }
+      public uint TileIndex { get; set; }
       public bool IsPassable { get; set; }
 
       public StaticSpriteSaveData() { }
 
-      public StaticSpriteSaveData( int textureIndex, int tileIndex, bool isPassable )
+      public StaticSpriteSaveData( uint textureIndex, uint tileIndex, bool isPassable )
       {
          TextureIndex = textureIndex;
          TileIndex = tileIndex;

--- a/DW3ArduinoWinDev/DW3ArduinoEditor/SaveData/TextureSetSaveData.cs
+++ b/DW3ArduinoWinDev/DW3ArduinoEditor/SaveData/TextureSetSaveData.cs
@@ -6,7 +6,7 @@ namespace DW3ArduinoEditor.SaveData
    {
       public uint Index { get; set; }
       public string Name { get; set; } = string.Empty;
-      public List<int> TexturePoolIndexes { get; set; } = [];
+      public List<uint> TexturePoolIndexes { get; set; } = [];
 
       public TextureSetSaveData() { }
 

--- a/DW3ArduinoWinDev/DW3ArduinoEditor/ViewModels/ActiveSpriteViewModel.cs
+++ b/DW3ArduinoWinDev/DW3ArduinoEditor/ViewModels/ActiveSpriteViewModel.cs
@@ -7,8 +7,8 @@ namespace DW3ArduinoEditor.ViewModels
 {
    public class ActiveSpriteViewModel : ViewModelBase
    {
-      private int _textureIndex;
-      public int TextureIndex
+      private uint _textureIndex;
+      public uint TextureIndex
       {
          get => _textureIndex;
          set => SetProperty( ref _textureIndex, value );

--- a/DW3ArduinoWinDev/DW3ArduinoEditor/ViewModels/StaticSpriteViewModel.cs
+++ b/DW3ArduinoWinDev/DW3ArduinoEditor/ViewModels/StaticSpriteViewModel.cs
@@ -4,15 +4,15 @@ namespace DW3ArduinoEditor.ViewModels
 {
    public class StaticSpriteViewModel : ViewModelBase
    {
-      private int _textureIndex;
-      public int TextureIndex
+      private uint _textureIndex;
+      public uint TextureIndex
       {
          get => _textureIndex;
          set => SetProperty( ref _textureIndex, value );
       }
 
-      private int _tileIndex;
-      public int TileIndex
+      private uint _tileIndex;
+      public uint TileIndex
       {
          get => _tileIndex;
          set => SetProperty( ref _tileIndex, value );

--- a/DW3ArduinoWinDev/DW3ArduinoEditor/ViewModels/TextureSetViewModel.cs
+++ b/DW3ArduinoWinDev/DW3ArduinoEditor/ViewModels/TextureSetViewModel.cs
@@ -19,7 +19,7 @@ namespace DW3ArduinoEditor.ViewModels
          set => SetProperty( ref _name, value );
       }
 
-      public ObservableCollection<int> TexturePoolIndexes { get; private set; } = [];
+      public ObservableCollection<uint> TexturePoolIndexes { get; private set; } = [];
 
       public TextureSetViewModel( uint index, string name )
       {


### PR DESCRIPTION
## Overview

Any indexes in the Editor should use unsigned integers, this is a first attempt to make that happen.