### PR TITLE
Show static sprites in tile map editor

### DIFF
--- a/DW3ArduinoEditor/DW3ArduinoEditor/TileMapPanel.cs
+++ b/DW3ArduinoEditor/DW3ArduinoEditor/TileMapPanel.cs
@@ -117,6 +117,28 @@ namespace DW3ArduinoEditor
          sender.PrepareBitmap();
       }
 
+      public static readonly DependencyProperty StaticSpriteTexturePoolProperty = DependencyProperty.Register(
+         nameof( StaticSpriteTexturePool ),
+         typeof( StaticSpriteTexturePool ),
+         typeof( TileMapPanel ),
+         new PropertyMetadata( OnStaticSpriteTexturePoolChanged ) );
+
+      public StaticSpriteTexturePool StaticSpriteTexturePool
+      {
+         get => (StaticSpriteTexturePool)GetValue( StaticSpriteTexturePoolProperty );
+         set => SetValue( StaticSpriteTexturePoolProperty, value );
+      }
+
+      private static void OnStaticSpriteTexturePoolChanged( DependencyObject obj, DependencyPropertyChangedEventArgs e )
+      {
+         if ( obj is not TileMapPanel sender || e.NewValue is not StaticSpriteTexturePool staticSpriteTexturePool )
+         {
+            return;
+         }
+
+         sender.PrepareBitmap();
+      }
+
       public static readonly DependencyProperty SelectedTileTextureSetProperty = DependencyProperty.Register(
          nameof( SelectedTileTextureSet ),
          typeof( TextureSetViewModel ),
@@ -139,15 +161,37 @@ namespace DW3ArduinoEditor
          sender.PrepareBitmap();
       }
 
-      public static readonly DependencyProperty SelectedTextureIndexProperty = DependencyProperty.Register(
-         nameof( SelectedTextureIndex ),
+      public static readonly DependencyProperty SelectedStaticSpriteTextureSetProperty = DependencyProperty.Register(
+         nameof( SelectedStaticSpriteTextureSet ),
+         typeof( TextureSetViewModel ),
+         typeof( TileMapPanel ),
+         new PropertyMetadata( OnSelectedStaticSpriteTextureSetChanged ) );
+
+      public TextureSetViewModel SelectedStaticSpriteTextureSet
+      {
+         get => (TextureSetViewModel)GetValue( SelectedTileTextureSetProperty );
+         set => SetValue( SelectedTileTextureSetProperty, value );
+      }
+
+      private static void OnSelectedStaticSpriteTextureSetChanged( DependencyObject obj, DependencyPropertyChangedEventArgs e )
+      {
+         if ( obj is not TileMapPanel sender || e.NewValue is not TextureSetViewModel selectedTileTextureSet )
+         {
+            return;
+         }
+
+         sender.PrepareBitmap();
+      }
+
+      public static readonly DependencyProperty SelectedTileTextureIndexProperty = DependencyProperty.Register(
+         nameof( SelectedTileTextureIndex ),
          typeof( int ),
          typeof( TileMapPanel ) );
 
-      public int SelectedTextureIndex
+      public int SelectedTileTextureIndex
       {
-         get => (int)GetValue( SelectedTextureIndexProperty );
-         set => SetValue( SelectedTextureIndexProperty, value );
+         get => (int)GetValue( SelectedTileTextureIndexProperty );
+         set => SetValue( SelectedTileTextureIndexProperty, value );
       }
 
       public static readonly DependencyProperty ShowStaticSpritesProperty = DependencyProperty.Register(
@@ -188,6 +232,7 @@ namespace DW3ArduinoEditor
          return new Size( _defaultTileSize * Zoom, _defaultTileSize * Zoom );
       }
 
+      // TODO: this could be optimized to only display the portion of the tile map that is visible
       private void PrepareBitmap()
       {
          if ( TileTexturePool is null || SelectedTileTextureSet is null || SelectedTileMap is null )
@@ -218,6 +263,18 @@ namespace DW3ArduinoEditor
             var tileSprite = TileTexturePool.GetSpriteFromIndex( SelectedTileTextureSet.TexturePoolIndexes[(int)SelectedTileMap.Tiles[i].TextureIndex] );
 
             tileSprite.DrawToBuffer( _rawBuffer, width, destX, destY );
+
+            if ( ShowStaticSprites && StaticSpriteTexturePool is not null && SelectedStaticSpriteTextureSet is not null )
+            {
+               foreach ( var s in SelectedTileMap.StaticSprites )
+               {
+                  if ( s.TileIndex == i )
+                  {
+                     var staticSprite = StaticSpriteTexturePool.GetSpriteFromIndex( s.TextureIndex );
+                     staticSprite.DrawToBuffer( _rawBuffer, width, destX, destY );
+                  }
+               }
+            }
          }
 
          // I don't know why I have to divide by 4 on the width, height
@@ -257,7 +314,7 @@ namespace DW3ArduinoEditor
       private void ChangeTile()
       {
          if ( _bitmap is null || SelectedTileMap is null || TileTexturePool is null || SelectedTileTextureSet is null ||
-            SelectedTextureIndex < 0 || SelectedTextureIndex >= SelectedTileTextureSet.TexturePoolIndexes.Count )
+            SelectedTileTextureIndex < 0 || SelectedTileTextureIndex >= SelectedTileTextureSet.TexturePoolIndexes.Count )
          {
             return;
          }
@@ -271,13 +328,13 @@ namespace DW3ArduinoEditor
          int offset = _cellY * tilesPerRow + _cellX;
          var tileViewModel = SelectedTileMap.Tiles[offset];
 
-         if ( tileViewModel.TextureIndex == SelectedTextureIndex )
+         if ( tileViewModel.TextureIndex == SelectedTileTextureIndex )
          {
             // No need to redraw the tile if it's the same
             return;
          }
 
-         tileViewModel.TextureIndex = (uint)SelectedTextureIndex;
+         tileViewModel.TextureIndex = (uint)SelectedTileTextureIndex;
 
          var byteBuffer = new byte[_defaultTileSize * _defaultTileSize * 4];
          var tileSprite = TileTexturePool.GetSpriteFromIndex( SelectedTileTextureSet.TexturePoolIndexes[(int)tileViewModel.TextureIndex] );

--- a/DW3ArduinoEditor/DW3ArduinoEditor/ViewModels/MainWindowViewModel.cs
+++ b/DW3ArduinoEditor/DW3ArduinoEditor/ViewModels/MainWindowViewModel.cs
@@ -16,7 +16,7 @@ namespace DW3ArduinoEditor.ViewModels
       private readonly HeaderGuidsViewModel _headerGuids = new();
       private readonly Palette _palette = new();
       public TileTexturePool TileTexturePool { get; private set; } = new();
-      private readonly StaticSpriteTexturePool _staticSpriteTexturePool = new();
+      public StaticSpriteTexturePool StaticSpriteTexturePool { get; private set; } = new();
       private readonly ActiveSpriteTexturePool _activeSpriteTexturePool = new();
       private readonly ActiveSpriteTexturePool _playerSpriteTexturePool = new();
 
@@ -73,6 +73,38 @@ namespace DW3ArduinoEditor.ViewModels
          }
       }
 
+      private TextureSetViewModel? _selectedStaticSpriteTextureSet;
+      public TextureSetViewModel? SelectedStaticSpriteTextureSet
+      {
+         get => _selectedStaticSpriteTextureSet;
+         set
+         {
+            if ( SetProperty( ref _selectedStaticSpriteTextureSet, value ) )
+            {
+               bool invalidTextureIndexFound = false;
+
+               if ( SelectedTileMap is not null && SelectedStaticSpriteTextureSet is not null )
+               {
+                  SelectedTileMap.StaticSpriteTextureSetIndex = SelectedStaticSpriteTextureSet.Index;
+
+                  foreach ( var sprite in SelectedTileMap.StaticSprites )
+                  {
+                     if ( sprite.TextureIndex >= SelectedStaticSpriteTextureSet.TexturePoolIndexes.Count )
+                     {
+                        sprite.TextureIndex = 0;
+                        invalidTextureIndexFound = true;
+                     }
+                  }
+               }
+
+               if ( invalidTextureIndexFound )
+               {
+                  MessageBox.Show( "The selected tile map contains static sprite texture indexes that are out of range, they will be reset to zero.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning );
+               }
+            }
+         }
+      }
+
       public MainWindowViewModel()
       {
          try
@@ -87,7 +119,7 @@ namespace DW3ArduinoEditor.ViewModels
 
          try
          {
-            _staticSpriteTexturePool = new( Constants.StaticSpriteTexturePoolImagePath, _palette );
+            StaticSpriteTexturePool = new( Constants.StaticSpriteTexturePoolImagePath, _palette );
          }
          catch ( Exception ex )
          {
@@ -128,7 +160,7 @@ namespace DW3ArduinoEditor.ViewModels
             {
                GameSaveDataSanityChecker.CheckSanity( saveData,
                                                       TileTexturePool.TilePaletteIndexes.Count,
-                                                      _staticSpriteTexturePool.StaticSpritePaletteIndexes.Count,
+                                                      StaticSpriteTexturePool.StaticSpritePaletteIndexes.Count,
                                                       _activeSpriteTexturePool.ActiveSpritePaletteIndexes.Count,
                                                       _playerSpriteTexturePool.ActiveSpritePaletteIndexes.Count );
 
@@ -147,7 +179,7 @@ namespace DW3ArduinoEditor.ViewModels
 
                foreach ( var set in saveData.StaticSpriteTextureSets )
                {
-                  StaticSpriteTextureSets.Add( new( _staticSpriteTexturePool, set ) );
+                  StaticSpriteTextureSets.Add( new( StaticSpriteTexturePool, set ) );
                }
 
                foreach ( var set in saveData.ActiveSpriteTextureSets )
@@ -324,7 +356,7 @@ namespace DW3ArduinoEditor.ViewModels
       private void WriteGameDataSource()
       {
          var generator = new GameDataGenerator();
-         generator.WriteGameDataSourceFile( new( _gameStartup, _headerGuids, TileMaps, TileTextureSets, StaticSpriteTextureSets, ActiveSpriteTextureSets ), _palette, TileTexturePool, _staticSpriteTexturePool, _activeSpriteTexturePool, _playerSpriteTexturePool );
+         generator.WriteGameDataSourceFile( new( _gameStartup, _headerGuids, TileMaps, TileTextureSets, StaticSpriteTextureSets, ActiveSpriteTextureSets ), _palette, TileTexturePool, StaticSpriteTexturePool, _activeSpriteTexturePool, _playerSpriteTexturePool );
          MessageBox.Show( "Game data source file has been written." );
       }
 

--- a/DW3ArduinoEditor/DW3ArduinoEditor/Views/MainWindow.xaml
+++ b/DW3ArduinoEditor/DW3ArduinoEditor/Views/MainWindow.xaml
@@ -159,8 +159,10 @@
                                          Margin="10,0,0,0"
                                          SelectedTileMap="{Binding SelectedTileMap}"
                                          TileTexturePool="{Binding TileTexturePool}"
+                                         StaticSpriteTexturePool="{Binding StaticSpriteTexturePool}"
                                          SelectedTileTextureSet="{Binding SelectedTileTextureSet}"
-                                         SelectedTextureIndex="{Binding SelectedIndex, ElementName=tileSelectionListView, Mode=TwoWay}"
+                                         SelectedStaticSpriteTextureSet="{Binding SelectedStaticSpriteTextureSet}"
+                                         SelectedTileTextureIndex="{Binding SelectedIndex, ElementName=tileSelectionListView, Mode=TwoWay}"
                                          ShowStaticSprites="{Binding IsChecked, ElementName=tileMapShowStaticSpritesCheckbox, Mode=OneWay }"/>
 
                   </StackPanel>


### PR DESCRIPTION
## Overview

This adds a checkbox to show or hide static sprites in the tile map editor. Note that it doesn't not take the transparent color into account, we might want to figure that out at some point, but it's not important for now.